### PR TITLE
Add tests to make sure Quicksand deletes global scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Quicksand is an Artisan command that you can run in your scheduler daily.
     ```
 3. Publish your config: `php artisan vendor:publish --provider="Tightenco\Quicksand\QuicksandServiceProvider"`
 4. Edit your config. Define which classes you'd like to have Quicksand clean up for you, how many days Quicksand should wait to clean up, and whether or not the results should be logged.
+    1. _Note: Quicksand will disregard any global scopes applied to models when deleting._
 5. Schedule the command in `app/Console/Kernel.php`:
 
     ```php

--- a/src/DeleteOldSoftDeletes.php
+++ b/src/DeleteOldSoftDeletes.php
@@ -61,7 +61,8 @@ class DeleteOldSoftDeletes extends Command
     {
         $daysBeforeDeletion = $modelConfig['days'] ?? $daysBeforeDeletion;
 
-        $affectedRows = $modelName::onlyTrashed()
+        $affectedRows = $modelName::withoutGlobalScopes()
+            ->onlyTrashed()
             ->where('deleted_at', '<', (new DateTime)->sub(new DateInterval("P{$daysBeforeDeletion}D"))->format('Y-m-d H:i:s'))
             ->forceDelete();
 

--- a/src/DeleteOldSoftDeletes.php
+++ b/src/DeleteOldSoftDeletes.php
@@ -61,8 +61,7 @@ class DeleteOldSoftDeletes extends Command
     {
         $daysBeforeDeletion = $modelConfig['days'] ?? $daysBeforeDeletion;
 
-        $affectedRows = $modelName::withoutGlobalScopes()
-            ->onlyTrashed()
+        $affectedRows = $modelName::onlyTrashed()
             ->where('deleted_at', '<', (new DateTime)->sub(new DateInterval("P{$daysBeforeDeletion}D"))->format('Y-m-d H:i:s'))
             ->forceDelete();
 

--- a/tests/QuicksandDeleteTest.php
+++ b/tests/QuicksandDeleteTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Log;
+use Models\GlobalScopedThing;
 use Models\Person;
 use Models\Place;
 use Models\Thing;
@@ -66,6 +67,23 @@ class QuicksandDeleteTest extends TestCase
         $this->deleteOldSoftDeletes();
 
         $this->assertEquals(15, Person::withTrashed()->count());
+    }
+
+     /** @test */
+    public function it_deletes_records_with_a_global_scope()
+    {
+        factory(GlobalScopedThing::class, 15)->states('global_scope_condition_met', 'deleted_old')->create();
+        factory(GlobalScopedThing::class, 15)->state('deleted_old')->create();
+
+        $this->setQuicksandConfig([
+            'models' => [
+                GlobalScopedThing::class,
+            ],
+        ]);
+
+        $this->deleteOldSoftDeletes();
+
+        $this->assertEquals(0, GlobalScopedThing::withTrashed()->count());
     }
 
     /** @test */

--- a/tests/QuicksandDeleteTest.php
+++ b/tests/QuicksandDeleteTest.php
@@ -83,7 +83,7 @@ class QuicksandDeleteTest extends TestCase
 
         $this->deleteOldSoftDeletes();
 
-        $this->assertEquals(0, GlobalScopedThing::withTrashed()->count());
+        $this->assertEquals(0, GlobalScopedThing::withoutGlobalScopes()->withTrashed()->count());
     }
 
     /** @test */

--- a/tests/database/factories/GlobalScopedThingFactory.php
+++ b/tests/database/factories/GlobalScopedThingFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(Models\GlobalScopedThing::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+    ];
+});
+
+$factory->state(Models\GlobalScopedThing::class, 'global_scope_condition_met', function ($faker) {
+    return [
+        'name' => 'Global Scope Applied',
+    ];
+});
+
+$factory->state(Models\GlobalScopedThing::class, 'deleted_old', function ($faker) {
+    return [
+        'deleted_at' => now()->subDays(rand(31, 100)),
+    ];
+});

--- a/tests/database/migrations/2014_10_12_000000_create_quicksand_global_scoped_things_table.php
+++ b/tests/database/migrations/2014_10_12_000000_create_quicksand_global_scoped_things_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateQuicksandGlobalScopedThingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('global_scoped_things', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('people');
+    }
+}

--- a/tests/models/GlobalScopedThing.php
+++ b/tests/models/GlobalScopedThing.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class GlobalScopedThing extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = ['name'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('name', function (Builder $builder) {
+            $builder->where('name', 'Global Scope Applied');
+        });
+    }
+}


### PR DESCRIPTION
 ~~As noted in this issue (https://github.com/tightenco/quicksand/issues/21), Quicksand currently does not delete models that have a global scope applied (if the particular model does not meet the requirements of that scope).~~

~~This PR updates the deletion code to add the `withoutGlobalScopes` call so that _all_ models are deleted regardless of scope.~~

**edit 12/07/18:** The previous message was incorrect. Quicksand _does_ disregard global scopes by default, because Laravel's `onlyTrashed` method appends `withoutGlobalScopes` as a part of the query. This PR now simply adds some tests to confirm that.