### PR TITLE
Feature/testing-the-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ See also the list of [contributors](https://github.com/tightenco/quicksand/graph
 
 This package is developed and maintained by [Tighten](https://tighten.co).
 
+## Testing
+You can test this package by running
+```
+composer test
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE) file for details

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
             "tests"
         ]
     },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
As I've proposed in issue #28, this PR adds a section about testing to the README.

Additionally, we can use the shorter `composer test` alias instead of running `vendor/bin/phpunit`.