### PR TITLE
Update version constraints for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,5 @@
                 "Tightenco\\Quicksand\\QuicksandServiceProvider"
             ]
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,17 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/config": "~5.6|~5.7|~5.8|~6.0|~7.0",
-        "illuminate/console": "~5.6|~5.7|~5.8|~6.0|~7.0",
-        "illuminate/log": "~5.6|~5.7|~5.8|~6.0|~7.0",
-        "illuminate/support": "~5.6|~5.7|~5.8|~6.0|~7.0"
+        "illuminate/config": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
+        "illuminate/console": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
+        "illuminate/log": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0",
+        "illuminate/support": "~5.6|~5.7|~5.8|~6.0|~7.0|~8.0"
     },
     "require-dev": {
+        "fzaninotto/faker": "^1.8",
+        "laravel/legacy-factories": "^1.0",
         "mockery/mockery": "^1.0.0",
-        "phpunit/phpunit": "~8.0",
-        "orchestra/testbench": "~3.0|~4.0|~5.0",
-        "fzaninotto/faker": "^1.8"
+        "orchestra/testbench": "~3.0|~4.0|~5.0|~6.0",
+        "phpunit/phpunit": "~8.0"
     },
     "autoload": {
         "psr-4": {
@@ -51,5 +52,7 @@
                 "Tightenco\\Quicksand\\QuicksandServiceProvider"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
This PR adds `~8.0` to the list of Illuminate component versions that Quicksand requires, updates `orchestra/testbench` to include `~6.0`, installs `laravel/legacy-factories` so the tests can all run as-is, and adds `"minimum-stability": "dev", "prefer-stable": true` so Laravel 8 and Testbench 6 will actually install.

I also created a new Laravel 8 app, installed Quicksand in it, and verified that:

- it installs with these new version constraints without conflicts
- the `quicksand:run` command works
- it logs the number of models it deleted
- it actually deletes the models
- it works from a schedule in the console kernel