### PR TITLE
Rename Tightenco namespace to Tighten

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Quicksand is an Artisan command that you can run in your scheduler daily.
 
 ## Installation
 
-1. Add Quicksand to your Composer file: `composer require tightenco/quicksand`
+1. Add Quicksand to your Composer file: `composer require tighten/quicksand`
 2. Register the Quicksand Service provider in `config/app.php` (you can skip this step if you're using Laravel 5.5 or higher due to package auto-discovery):
 
     ```php
     'providers' => [
         ...
 
-        Tightenco\Quicksand\QuicksandServiceProvider::class,
+        Tighten\Quicksand\QuicksandServiceProvider::class,
     ```
-3. Publish your config: `php artisan vendor:publish --provider="Tightenco\Quicksand\QuicksandServiceProvider"`
+3. Publish your config: `php artisan vendor:publish --provider="Tighten\Quicksand\QuicksandServiceProvider"`
 4. Edit your config. Define which classes and/or pivot tables you'd like to have Quicksand clean up for you, how many days Quicksand should wait to clean up, and whether or not the results should be logged. The default `'days'` until cleaning up is overridable by specifying a `'days'` key when registering a model or pivot table:
 
     1. _Note: Quicksand will disregard any global scopes applied to models when deleting._

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quicksand is an Artisan command that you can run in your scheduler daily.
 
 ## Installation
 
-1. Add Quicksand to your Composer file: `composer require tighten/quicksand`
+1. Add Quicksand to your Composer file: `composer require tightenco/quicksand`
 2. Register the Quicksand Service provider in `config/app.php` (you can skip this step if you're using Laravel 5.5 or higher due to package auto-discovery):
 
     ```php

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tightenco/quicksand",
+    "name": "tighten/quicksand",
     "description": "Easily schedule regular cleanup of old soft-deleted Eloquent data.",
     "homepage": "https://github.com/tighten/quicksand",
     "license": "MIT",
@@ -37,7 +37,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Tightenco\\Quicksand\\": "src"
+            "Tighten\\Quicksand\\": "src"
         },
         "classmap": [
             "tests"
@@ -49,7 +49,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Tightenco\\Quicksand\\QuicksandServiceProvider"
+                "Tighten\\Quicksand\\QuicksandServiceProvider"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tighten/quicksand",
+    "name": "tightenco/quicksand",
     "description": "Easily schedule regular cleanup of old soft-deleted Eloquent data.",
     "homepage": "https://github.com/tighten/quicksand",
     "license": "MIT",

--- a/src/DeleteOldSoftDeletes.php
+++ b/src/DeleteOldSoftDeletes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tightenco\Quicksand;
+namespace Tighten\Quicksand;
 
 use DateInterval;
 use DateTime;

--- a/src/QuicksandServiceProvider.php
+++ b/src/QuicksandServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tightenco\Quicksand;
+namespace Tighten\Quicksand;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/tests/QuicksandDeleteTest.php
+++ b/tests/QuicksandDeleteTest.php
@@ -8,7 +8,7 @@ use Models\Thing;
 use Monolog\Logger;
 use Monolog\Handler\TestHandler;
 use Orchestra\Testbench\TestCase;
-use Tightenco\Quicksand\DeleteOldSoftDeletes;
+use Tighten\Quicksand\DeleteOldSoftDeletes;
 
 class QuicksandDeleteTest extends TestCase
 {
@@ -310,7 +310,7 @@ class QuicksandDeleteTest extends TestCase
         $this->deleteOldSoftDeletes();
 
         $expectedLogOutput = sprintf(
-            'Tightenco\Quicksand\DeleteOldSoftDeletes force deleted these number of rows: %s',
+            'Tighten\Quicksand\DeleteOldSoftDeletes force deleted these number of rows: %s',
             print_r(['Models\Person' => 1], true)
         );
 


### PR DESCRIPTION
This PR renames the `Tightenco` namespace to `Tighten`.